### PR TITLE
Reduce circle-ci testing to just single ubuntu package except for new tags.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,4 @@ test:
     - python3 -m pip install -vv --upgrade --force-reinstall "dist/packagecore-$(cat VERSION).tar.gz"
     - packagecore -C test -p ubuntu16.04 1.2.3 4 || exit 1
     - python3 -m pip uninstall packagecore
+    - if [[ "${CIRCLE_TAG}" == "v${CIRCLE_TAG#v}" ]]; then packagecore -C test 1.2.3 5 || exit 1; fi

--- a/circle.yml
+++ b/circle.yml
@@ -10,5 +10,5 @@ test:
     - ./setup.py test
     - ./setup.py sdist
     - python3 -m pip install -vv --upgrade --force-reinstall "dist/packagecore-$(cat VERSION).tar.gz"
-    - pushd test; packagecore 1.2.3 4 || exit 1; popd
+    - packagecore -C test -p ubuntu16.04 1.2.3 4 || exit 1
     - python3 -m pip uninstall packagecore


### PR DESCRIPTION
Closes #59 