### PR TITLE
Disable 'arch' in tag test

### DIFF
--- a/test/packagecore.yaml
+++ b/test/packagecore.yaml
@@ -18,9 +18,9 @@ packages:
   amazonlinux2017.03:
     builddeps:
       - gcc
-  archlinux:
-    builddeps:
-      - gcc
+#  archlinux:
+#    builddeps:
+#      - gcc
   centos7.3:
     builddeps:
       - gcc


### PR DESCRIPTION
Just temporary until the arch-linux image is updated.