### PR TITLE
Re-enable arch linux

### DIFF
--- a/packagecore.yaml
+++ b/packagecore.yaml
@@ -9,15 +9,15 @@ commands:
   testinstall:
     - packagecore -h || exit 1 
 packages:
-#  archlinux:
-#    builddeps:
-#      - python
-#      - python-setuptools
-#    deps:
-#      - python
-#      - python-yaml
-#      - python-setuptools
-#      - docker
+  archlinux:
+    builddeps:
+      - python
+      - python-setuptools
+    deps:
+      - python
+      - python-yaml
+      - python-setuptools
+      - docker
   fedora25:
     builddeps:
       - python3

--- a/test/packagecore.yaml
+++ b/test/packagecore.yaml
@@ -18,9 +18,9 @@ packages:
   amazonlinux2017.03:
     builddeps:
       - gcc
-#  archlinux:
-#    builddeps:
-#      - gcc
+  archlinux:
+    builddeps:
+      - gcc
   centos7.3:
     builddeps:
       - gcc


### PR DESCRIPTION
Re-ran arch linux recently and it was passing fine, gonna try re-enabling it to see how long it takes with the january image.

https://hub.docker.com/r/packagecore/archlinux/tags/

If this works -- it closes #128.