### PR TITLE
Allow to specify more than one package to be built with `--package`

### DIFF
--- a/packagecore/__main__.py
+++ b/packagecore/__main__.py
@@ -57,7 +57,7 @@ class ParseCommaSeparatedListAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         try:
-            assert type(values) is str
+            assert isinstance(values, str)
         except AssertionError:
             raise TypeError("%s is not a string" % values)
         args = values.split(",")
@@ -95,7 +95,7 @@ def main():
                         "Defaults to '%(default)s'.")
 
     parser.add_argument("-p", "--packages", dest="distributions",
-                        metavar="<distribution names>", default=[],
+                        metavar="<distribution names>", default=None,
                         type=str, action=ParseCommaSeparatedListAction,
                         help="Instead of building all packages in a configuration file, build "
                         "packages for specific distributions (comma-separated list).")

--- a/packagecore/__main__.py
+++ b/packagecore/__main__.py
@@ -98,7 +98,7 @@ def main():
                         metavar="<distribution names>", default=[],
                         type=str, action=ParseCommaSeparatedListAction,
                         help="Instead of building all packages in a configuration file, build "
-                        "packages for specific distributions.")
+                        "packages for specific distributions (comma-separated list).")
 
     parser.add_argument("-o", "--outputdir", dest="outputdir",
                         metavar="<output directory>", default=outputdir,

--- a/packagecore/__main__.py
+++ b/packagecore/__main__.py
@@ -42,6 +42,28 @@ class ShowDistributionsAction(argparse.Action):
         parser.exit()
 
 
+class ParseCommaSeparatedListAction(argparse.Action):
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 nargs=None,
+                 **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super(ParseCommaSeparatedListAction, self).__init__(
+            option_strings,
+            dest=dest,
+            **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            assert type(values) is str
+        except AssertionError:
+            raise TypeError("%s is not a string" % values)
+        args = values.split(",")
+        setattr(namespace, self.dest, args)
+
+
 def getVersion():
     import pkg_resources
     versionBytes = pkg_resources.resource_string(__name__, "VERSION")
@@ -74,7 +96,7 @@ def main():
 
     parser.add_argument("-p", "--packages", dest="distributions",
                         metavar="<distribution names>", default=[],
-                        nargs="+", type=str,
+                        type=str, action=ParseCommaSeparatedListAction,
                         help="Instead of building all packages in a configuration file, build "
                         "packages for specific distributions.")
 

--- a/packagecore/__main__.py
+++ b/packagecore/__main__.py
@@ -94,7 +94,7 @@ def main():
                         default="./", help="The source directory to build. "
                         "Defaults to '%(default)s'.")
 
-    parser.add_argument("-p", "--packages", dest="distributions",
+    parser.add_argument("-p", "--package", "--packages", dest="distributions",
                         metavar="<distribution names>", default=None,
                         type=str, action=ParseCommaSeparatedListAction,
                         help="Instead of building all packages in a configuration file, build "

--- a/packagecore/__main__.py
+++ b/packagecore/__main__.py
@@ -72,10 +72,11 @@ def main():
                         default="./", help="The source directory to build. "
                         "Defaults to '%(default)s'.")
 
-    parser.add_argument("-p", "--package", dest="distribution",
-                        metavar="<distribution name>", default=None,
+    parser.add_argument("-p", "--packages", dest="distributions",
+                        metavar="<distribution names>", default=[],
+                        nargs="+", type=str,
                         help="Instead of building all packages in a configuration file, build "
-                        "a package for a specific distribution.")
+                        "packages for specific distributions.")
 
     parser.add_argument("-o", "--outputdir", dest="outputdir",
                         metavar="<output directory>", default=outputdir,
@@ -122,7 +123,7 @@ def main():
     packager = Packager(conf=conf.getData(), srcDir=args.sourceDir,
                         outputDir=args.outputdir,
                         version=version, release=release,
-                        distribution=args.distribution)
+                        distributions=args.distributions)
 
     print("This program is licensed under the GPLv2, a copy of which is ")
     print("included with this software package.")

--- a/packagecore/configparser.py
+++ b/packagecore/configparser.py
@@ -25,7 +25,7 @@ def _stringifyCommands(cmds):
 
 
 def parse(conf, version, release):
-    builds = []
+    builds = {}
 
     # set globals
     projectPreCompileCommands = ""
@@ -106,6 +106,6 @@ def parse(conf, version, release):
         if "container" in data:
             buildData.container = data["container"]
 
-        builds.append(buildData)
+        builds[buildData.osName] = buildData
 
     return builds

--- a/packagecore/configparser_test.py
+++ b/packagecore/configparser_test.py
@@ -68,7 +68,7 @@ class TestPackager(unittest.TestCase):
     def test_init(self):
         builds = parse(CONF, "1.2.3", 4)
 
-        for build in builds:
+        for build in builds.values():
             self.assertEqual(build.name, CONF["name"])
             self.assertEqual(build.maintainer, CONF["maintainer"])
             self.assertEqual(build.license, CONF["license"])

--- a/packagecore/packager.py
+++ b/packagecore/packager.py
@@ -40,7 +40,7 @@ class Packager:
     #
     # @return The new Packager.
     def __init__(self, conf, srcDir, outputDir, version, release,
-                 distributions=[]):
+                 distributions=None):
         self._outputDir = outputDir
         self._srcDir = srcDir
 

--- a/packagecore/packager.py
+++ b/packagecore/packager.py
@@ -36,11 +36,11 @@ class Packager:
     # @param srcDir The directory containing the projects source.
     # @param version The version of packages to generate.
     # @param release The release number.
-    # @param distribution The distribution to build a package for.
+    # @param distributions The distributions to build a package for.
     #
     # @return The new Packager.
     def __init__(self, conf, srcDir, outputDir, version, release,
-                 distribution=None):
+                 distributions=[]):
         self._outputDir = outputDir
         self._srcDir = srcDir
 
@@ -49,21 +49,17 @@ class Packager:
 
         builds = parse(conf=conf, version=version, release=release)
 
-        if not distribution is None:
-            soloBuild = None
-            for build in builds:
-                if build.osName == distribution:
-                    soloBuild = build
-                    break
+        if distributions:
+            self._queue = []
+
+            for distribution in distributions:
+                if distribution in builds.keys():
+                    self._queue.append(builds[distribution])
                 else:
-                    # skip this package
-                    print("Skipping '%s'." % build.osName)
-            if soloBuild is None:
-                raise PackageNotFoundError("No '%s' listed in configuration." %
-                                           distribution)
-            self._queue = [soloBuild]
+                    raise PackageNotFoundError("No '%s' listed in configuration." %
+                                               distribution)
         else:
-            self._queue = builds
+            self._queue = builds.values()
 
         self._docker = Docker()
 


### PR DESCRIPTION
This PR allows to specify more than one package to be built by PackageCore with the `--package` option (now `--packages`). This option accepts a comma-separated list.

The `parse` function from `packagecore/configparser.py` now returns a hash table (`dict`) with the OS names as key values. This way, it is no more necessary to iterate over the list of packages parsed from the configuration file to do the matching between them and the list given by `--packages`.