### PR TITLE
Issue176

### DIFF
--- a/packagecore/docker.py
+++ b/packagecore/docker.py
@@ -241,7 +241,7 @@ class Docker:
         # determine if we're using lxc or libcontainer
         grep = Popen(["docker", "info"], stdout=PIPE, stderr=PIPE)
         stdout = grep.communicate()[0]
-        output = str(stdout)
+        output = stdout.decode('utf8')
         print("DOCKER_INFO")
         print(output)
         if output.find("lxc-") < 0:

--- a/packagecore/docker.py
+++ b/packagecore/docker.py
@@ -60,7 +60,6 @@ def _uncheckedDockerCommand(cmd):
     status = proc.wait()
     return status
 
-
 class MockContainer:
     def __init__(self):
         _makeDir(self.getSharedDir())
@@ -99,7 +98,7 @@ class DockerContainer:
         if environment:
             for name, value in environment.items():
                 envCommands.append("-e")
-                envCommands.append("%s='%s'" % (name, value))
+                envCommands.append("%s=%s" % (name, value))
 
         self._image = imageName
         # get a unique name


### PR DESCRIPTION
This PR remove double single quote from the environment variable. Previously using,

     $ packagecore -e https_proxy=http://proxy.ncbs.res.in:3128 ... 

would result in variable `https_proxy` set as `''http://proxy.ncbs.res.in''` (inside double `'`, `pacman` didn't like it.).

This version worked well for me. I could build on `Arch` and `ubuntu`.  Related to #176, #177